### PR TITLE
support adoptopenjdk

### DIFF
--- a/installer/src/main/java/com/github/dcevm/installer/ConfigurationInfo.java
+++ b/installer/src/main/java/com/github/dcevm/installer/ConfigurationInfo.java
@@ -268,7 +268,7 @@ public enum ConfigurationInfo {
     }
 
     public String getJavaVersion(Path jreDir) throws IOException {
-        return getVersionHelper(jreDir, ".*java version.*\"(.*)\".*", true, false);
+        return getVersionHelper(jreDir, ".*(?:java|openjdk) version.*\"(.*)\".*", true, false);;
     }
 
     final public String getDCEVersion(Path jreDir, boolean altjvm) throws IOException {


### PR DESCRIPTION
Adoptopenjdk's version outoput is:
```
$ java -version
openjdk version "1.8.0_252"
OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_252-b09)
OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.252-b09, mixed mode)
```
The origin version cannot get this version. 